### PR TITLE
prevent 0 division to fix #11

### DIFF
--- a/src/megapix-image.js
+++ b/src/megapix-image.js
@@ -54,7 +54,8 @@
       }
       py = (ey + sy) >> 1;
     }
-    return py / ih;
+    var ratio = (py / ih);
+    return (ratio===0)?1:ratio;
   }
 
   /**


### PR DESCRIPTION
When using alpha PNGs, the vertical ratio was 0 so i just prevented this from happening :)

Here's a sample image.

![bresil](https://f.cloud.github.com/assets/124937/173477/fe0674c2-7add-11e2-8574-74d2204c9540.png)

Hope this helps :)
