### PR TITLE
If canvas passed to library is too big  toDataURL returns “data:,” even ...

### DIFF
--- a/src/megapix-image.js
+++ b/src/megapix-image.js
@@ -167,6 +167,14 @@
     }
   }
 
+  function checkCanvasIfItIsNotToBig(canvas, options) {
+    while(canvas.toDataURL('image/jpeg') == 'data:,' && canvas.width>0 && canvas.height>0) {
+        canvas.width -= 10;
+        canvas.height -= 10;
+    }
+      options.width = canvas.width;
+      options.height = canvas.height;
+  }
 
   /**
    * MegaPixImage class
@@ -235,6 +243,7 @@
     if (tagName === 'img') {
       target.src = renderImageToDataURL(this.srcImage, opt, doSquash);
     } else if (tagName === 'canvas') {
+      checkCanvasIfItIsNotToBig(target, opt);
       renderImageToCanvas(this.srcImage, target, opt, doSquash);
     }
     if (typeof this.onrender === 'function') {


### PR DESCRIPTION
...if canvas is empty. It’s because of too less memory on iPad/iPhone. New method setup maximum width & height for device.
