### PR TITLE
Fix false positive detection

### DIFF
--- a/src/megapix-image.js
+++ b/src/megapix-image.js
@@ -207,10 +207,16 @@
       return;
     }
     options = options || {};
-    var imgWidth = this.srcImage.naturalWidth, imgHeight = this.srcImage.naturalHeight,
+    var srcImage = this.srcImage,
+        src = srcImage.src,
+        srcLength = src.length,
+        imgWidth = srcImage.naturalWidth, imgHeight = srcImage.naturalHeight,
         width = options.width, height = options.height,
         maxWidth = options.maxWidth, maxHeight = options.maxHeight,
-        doSquash = !this.blob || this.blob.type === 'image/jpeg';
+        doSquash = this.blob && this.blob.type === 'image/jpeg' ||
+                   src.indexOf('data:image/jpeg') === 0 ||
+                   src.indexOf('.jpg') === srcLength - 4 || 
+                   src.indexOf('.jpeg') === srcLength - 5;
     if (width && !height) {
       height = (imgHeight * width / imgWidth) << 0;
     } else if (height && !width) {


### PR DESCRIPTION
PNGs or GIFs can currently be improperly detected as JPEGs, this fixes that:
1st it checks for mime on the blob
2nd it checks for data:image/jpeg for dataURLs
3rd it does a check for .jpg or .jpeg for provided string srcs

Otherwise, any transparent PNGs or GIFs will also be detected as "squashed".

Thanks for the great library!
