### PR TITLE
Adding srcImage.onerror handler.

### DIFF
--- a/src/megapix-image.js
+++ b/src/megapix-image.js
@@ -72,6 +72,7 @@
    */
   function renderImageToCanvas(img, canvas, options, doSquash) {
     var iw = img.naturalWidth, ih = img.naturalHeight;
+    if (!(iw+ih)) return;
     var width = options.width, height = options.height;
     var ctx = canvas.getContext('2d');
     ctx.save();


### PR DESCRIPTION
This is mainly to allow the revokeObjectURL being called regardless of the image being properly loaded or no, otherwise we'd still have a memory leak.
